### PR TITLE
Fix some `no_std` nits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,21 @@ jobs:
         with:
           components: clippy
       - run: cargo clippy --all-features -- -D warnings
+
+  # Test no_std build-only
+  build-nostd:
+    name: Build on no_std target (thumbv7em-none-eabi)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: thumbv7em-none-eabi
+      - uses: taiki-e/install-action@cargo-hack
+      # No default features build
+      - name: no_std / no feat
+        run: cargo build --target thumbv7em-none-eabi --release --no-default-features
+      - name: no_std / cargo hack
+        run: cargo hack
+        build --target thumbv7em-none-eabi --release --each-feature --exclude-features default,std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 keywords = ["cryptography", "crypto", "post-quantum", "encapsulation", "kem"]
 categories = ["cryptography", "no-std"]
 
+[features]
+default = []
+std = ["alloc"]
+alloc = []
+
 [dependencies]
 kem = "0.3.0-pre.0"
 rand_core = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,6 @@ edition = "2021"
 keywords = ["cryptography", "crypto", "post-quantum", "encapsulation", "kem"]
 categories = ["cryptography", "no-std"]
 
-[features]
-default = []
-std = ["alloc"]
-alloc = []
-
 [dependencies]
 kem = "0.3.0-pre.0"
 rand_core = "0.6.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![forbid(unsafe_code)]
 #![warn(
-//    clippy::unwrap_used, TODO: needs addressing
+    clippy::unwrap_used, TODO: needs addressing
     missing_docs,
     rust_2018_idioms,
     unused_lifetimes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
-#![no_std]
-
-#[cfg(test)]
-#[macro_use]
-extern crate std;
+#![forbid(unsafe_code)]
+#![warn(
+//    clippy::unwrap_used, TODO: needs addressing
+    missing_docs,
+    rust_2018_idioms,
+    unused_lifetimes,
+    unused_qualifications
+)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
+#![doc = include_str!("../README.md")]
 
 mod consts;
 mod gen;


### PR DESCRIPTION
Noticed this - separate PR
- #2 

You'll need std for it's `Error` - however it's being brought to core but that requires high MSRV 1.80