### PR TITLE
Add pubkey hash to the `KemPublicKey` struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 rand_core = "0.6.4"
 sha3 = { version = "0.10.8", default-features = false }
-subtle = { version = "2.6.0", default-features = false, features = ["const-generics"] }
+subtle = { version = "2.6.0", default-features = false, features = [
+    "const-generics",
+] }
 zeroize = { version = "1.8.1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -76,7 +76,7 @@ macro_rules! variant_impl {
 
                 /// Returns the public key corresponding to this secret key
                 pub fn public_key(&self) -> $pubkey_name {
-                    $pubkey_name(self.0.public_key().clone())
+                    $pubkey_name(self.0.public_key())
                 }
             }
 


### PR DESCRIPTION
Previously, every encapsulation recomputed `SHA3(pk)`, which is quite expensive